### PR TITLE
feat(docker): add Dockerfile for API app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+dist
+.git
+*.log
+.env
+.env.local
+coverage
+.turbo

--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+coverage
+.env
+.env.local
+*.log
+.git

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npx prisma generate
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/prisma ./prisma
+
+EXPOSE 4000
+CMD ["node", "dist/main"]


### PR DESCRIPTION
## Summary
- Adds a multi-stage `apps/api/Dockerfile` for the NestJS API, self-contained within the `apps/api` build context (matches `docker-compose.yml`'s existing `context: ./apps/api` for the `api` service).
- Adds `.dockerignore` at repo root and inside `apps/api` (the api build context is scoped to `apps/api`, so a root-only `.dockerignore` wouldn't apply to that build).

## Not included (flagged, needs a decision)
- **`apps/web/Dockerfile`**: `apps/web` does not exist in this repo yet — only `apps/api` is scaffolded, even though `docker-compose.yml` already references a `web` service/build context. No Next.js app to containerize yet.
- **`apps/api/.env.example`**: a complete root-level `.env.example` already covers every var read by `apps/api/src/config/configuration.ts` (DB, JWT + refresh secret, GitHub OAuth + API token, app URLs). Adding a narrower per-app copy would just diverge/duplicate.
- **Pre-existing build failure, unrelated to Docker**: `apps/api/src/main.ts` imports `./app.module`, but `src/app.module.ts` does not exist anywhere in git history. `npm run build` (and the Docker build) fails on this today. CI on `main` has been red since 2026-05-03 for the same reason (`gh run list --branch main`). This Dockerfile is correct for the current structure, but the image won't build until `app.module.ts` is added — that's an app-code fix outside the scope of this Docker task.

## Test plan
- [x] `docker build .` from `apps/api` — reaches `npm run build` and fails only on the pre-existing missing `app.module.ts` (confirmed CI is already failing on `main` for the same reason)
- [ ] Once `app.module.ts` exists, re-run `docker build ./apps/api` to confirm the image builds end to end
- [ ] Scaffold `apps/web` and add its Dockerfile in a follow-up PR