### PR TITLE
fix(api): add missing app.module.ts and fix container boot chain

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
+RUN apk add --no-cache openssl
 
 COPY package*.json ./
 RUN npm install
@@ -10,6 +11,7 @@ RUN npm run build
 
 FROM node:20-alpine
 WORKDIR /app
+RUN apk add --no-cache openssl
 
 ENV NODE_ENV=production
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import configuration from './config/configuration';
+import { PrismaModule } from './prisma/prisma.module';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [configuration],
+    }),
+    PrismaModule,
+  ],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "prisma", "**/*spec.ts"]
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "target": "ES2021",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
## Summary
`apps/api/src/app.module.ts` never existed in git history (confirmed via `git log --all -- apps/api/src/app.module.ts`, empty), which is why CI on `main` has been red since 2026-05-03 and why the API Docker image (added in #27) can't build.

Adding a literal empty `@Module({})` (as originally suggested) compiles, but crashes immediately on boot: `main.ts` calls `app.get(ConfigService)` right after `NestFactory.create`, and nothing registers `ConfigModule`. I verified this by actually building and running the container end-to-end (real Postgres, not just `npm run build`), and it surfaced three more pre-existing bugs blocking a working container:

1. **`app.module.ts`** now registers `ConfigModule.forRoot({ isGlobal: true, load: [configuration] })` + `PrismaModule` — the only real infra pieces that exist in this repo today. No feature modules (auth/users/tools/challenges/prs/leaderboard/wallet/github/admin) exist yet despite being referenced in the Swagger tags in `main.ts` — that's separate, larger work.
2. **`tsconfig.build.json`**: was compiling `prisma/seed.ts` alongside `src/`, which pushed TypeScript's inferred `rootDir` up a level, producing `dist/src/main.js` instead of `dist/main.js` — the path both `package.json`'s `start` script and the Dockerfile `CMD` expect. Excluded `prisma/` from the build (seed already runs separately via `ts-node`).
3. **`tsconfig.json`**: had `allowSyntheticDefaultImports` but not `esModuleInterop`, so `import cookieParser from 'cookie-parser'` compiled to a `.default` access on a CJS export that has none → crashed at boot with `cookie_parser_1.default is not a function`.
4. **`apps/api/Dockerfile`**: `node:20-alpine` has no OpenSSL, so `prisma generate` couldn't detect a version and defaulted to a `libssl-1.1` engine binary that isn't present at runtime → `PrismaClientInitializationError`. Installed `openssl` in both build stages so Prisma correctly targets the musl-openssl-3.0.x engine.

## Known gap not addressed here
`docker-compose.yml`'s healthcheck for the `api` service calls `GET /api/health`, which 404s — no health endpoint/controller exists. Flagging rather than fabricating a controller outside this PR's scope.

## Test plan
- [x] `docker build .` from `apps/api` succeeds
- [x] Ran the built image against a real `postgres:16-alpine` container on a shared Docker network — Nest boots, Prisma connects (`Database connected` / `Nest application successfully started`), `GET /api/docs` returns 200
- [ ] Add a real `/api/health` route so the compose healthcheck passes
- [ ] Scaffold the actual feature modules (auth/users/tools/etc.)