### PR TITLE
fix(docker): build API image from repo root to match Tekton/Kaniko context

### DIFF
--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,7 +1,0 @@
-node_modules
-dist
-coverage
-.env
-.env.local
-*.log
-.git

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,12 +2,15 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 RUN apk add --no-cache openssl
 
-COPY package*.json ./
+COPY package*.json turbo.json ./
+COPY apps/api/package*.json ./apps/api/
+
 RUN npm install
 
 COPY . .
-RUN npx prisma generate
-RUN npm run build
+
+RUN cd apps/api && npx prisma generate
+RUN cd apps/api && npm run build
 
 FROM node:20-alpine
 WORKDIR /app
@@ -15,10 +18,10 @@ RUN apk add --no-cache openssl
 
 ENV NODE_ENV=production
 
+COPY --from=builder /app/apps/api/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/package*.json ./
-COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/apps/api/package*.json ./
+COPY --from=builder /app/apps/api/prisma ./prisma
 
 EXPOSE 4000
 CMD ["node", "dist/main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,8 @@ services:
 
   api:
     build:
-      context: ./apps/api
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: apps/api/Dockerfile
     container_name: benflux_devtools_api
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
Kaniko builds the `api` image with the **repo root** as build context, not `apps/api/`. The Dockerfile from #27/#28 assumed a context scoped to `apps/api`, so Kaniko's working directory never contained `apps/api/prisma/`, and `prisma generate` failed:
```
Error: Could not find Prisma Schema that is required for this command.
Checked following paths:
  schema.prisma: file not found
  prisma/schema.prisma: file not found
```

- `apps/api/Dockerfile`: copies root `package*.json`/`turbo.json` + `apps/api/package*.json`, `npm install`s from root (workspaces), then `cd apps/api` for `prisma generate` and `nest build`. Verified with `docker build -f apps/api/Dockerfile .` from repo root that npm workspaces hoist everything to `/app/node_modules` (not `apps/api/node_modules`) — the production stage copies `node_modules` from the builder's root, and `dist`/`package.json`/`prisma` from `apps/api/`.
- `docker-compose.yml`: `api` service `context` changed from `./apps/api` to `.` (root), `dockerfile: apps/api/Dockerfile` — otherwise local `docker-compose build` would diverge from what Kaniko actually does. Verified with `docker compose build api`.
- Removed `apps/api/.dockerignore` — it only applied when the build context was scoped to `apps/api`; the root `.dockerignore` (added in #27) now covers this build.

## Test plan
- [x] `docker build -f apps/api/Dockerfile .` from repo root succeeds, `prisma generate` finds the schema
- [x] `docker compose build api` succeeds with the updated context
- [x] Ran the built image against a real `postgres:16-alpine` container — Nest boots, Prisma connects, `GET /api/docs` returns 200