### PR TITLE
fix: add packageManager field for Turborepo 2.10+ workspace resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "Benflux DevTools — Community-driven developer tools platform powered by DevArena",
+  "packageManager": "npm@10.9.0",
   "workspaces": [
     "apps/*"
   ],


### PR DESCRIPTION
turbo run test/build/etc failed in CI with "Could not resolve workspace... Missing devEngines.packageManager or legacy packageManager field" — Turbo 2.10+ requires this to detect the workspace's package manager.

## Description

<!-- What does this PR do? Why? -->

## Related Issue

Closes #<!-- issue number -->

## Type of change

- [ ] New feature (challenge task)
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor / improvement
- [ ] Infrastructure / tooling

## Checklist

- [ ] Code builds without errors (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] Tested in the browser end-to-end
- [ ] No console errors or warnings
- [ ] PR is focused on a single task (not multiple issues)

## Screenshots (if UI change)

<!-- Add before/after screenshots -->

## Notes for reviewer

<!-- Anything the reviewer should know -->
