### PR TITLE
fix: sealed secret must apply before migrate-job hook (deadlock)

### DIFF
--- a/helm/sealed-secrets/secrets-dev.yaml
+++ b/helm/sealed-secrets/secrets-dev.yaml
@@ -4,6 +4,9 @@ kind: SealedSecret
 metadata:
   name: benflux-devtools-api-secrets
   namespace: benflux-devtools-dev
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
 spec:
   encryptedData:
     DATABASE_URL: AgCIocTDhN/XML5xzKprCqEIr7cRBwAzAHh3Ljg7AfWDk6OJ8iXVOBDmJwO1I/CQrKyvTjwk3IAnGLP+wWYk7U6ut+tH4S+CJIm0ySifqY3p0kg6gw2JyX3fAhpu2oO7Bd3+8KF9filEUqE5Q0hNqDh0cCrKPZ+5UDrv94RSW3dcPZGzANyfTJlHye40yYwPsm7rnaMvX42uXxW7Rv6WkPSlrPudNvq19gez4a0EC/WEjk8zmMZUiSzxOJJ1VTnBonPASEoxrroSruDP/u/z/fYP8bs7ob8zkgF1D7S3xeV0zeaasMdjFRci6nn20zLWcuDI1IT58XuDpg/Gua2krhpb3wCdLB73jM+EiVVb2V6HZQye6sP/gtEbGVrkZADb1rGLd4kR2+EPm/34TQEEOnI8xHU5+LOX088MLqUZgAO2Iqf2PEdTD14DhmK1vqFmn1DnClKTTIMZ4HIqSiZo63pgYaZy3YPmkLCi6E0B1jBAL19OhcNNX8pap2rQgLH3dxINxfX+UAuHp6HILOA6wjJS3uNrsDG2tlXn21iBrOtyddHkz6uFL+nZAjy+0I8qv6oCa9jC0+rBTAVNiinoMGjNWLd+NsZuk11IUssTT+y121cmTs3q2WYwWxCEqqitwcMJYV4b5Pl8SP/hjLDoyMPMGjeyagMV9Z6N0XCvs2g7IsWzpTacvS9G3c5X/fqsD5AERqC51aOHLhXCeIJHT3OTsSd+Mby5JFIZZ2jSxa6FjAi5yFGkTemjq/Tqoqh9TpbD6etUEbAYiwQnQk51dAaHGysnSLoMlKRYLl60gUCf8YkUZA5HTFya9KvEZ3j8aJRdA4YLwH2X5+dft5qtHQ6ROcFQKfOJqN3z4v+c+Q==


### PR DESCRIPTION
benflux-devtools-dev est bloqué en boucle sur ArgoCD : le Job pre-sync migrate-job (hook-weight -5) a besoin de DATABASE_URL (dans le secret benflux-devtools-api-secrets), mais ce secret n'a pas d'annotation helm.sh/hook donc il n'est appliqué qu'après tous les hooks pre-sync — un deadlock. Ajout de hook-weight -10 comme sur benflux-auth pour que le secret s'applique avant le Job de migration.